### PR TITLE
Updates ReactNativeWindowsDir prop in vcxproj to support symlinks properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/crazycodeboy/react-native-splash-screen#readme",
   "devDependencies": {
-    "react-native": "^0.63.4",
-    "react-native-windows": "^0.63.14"
+    "react-native": "0.64.1",
+    "react-native-windows": "0.64.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/crazycodeboy/react-native-splash-screen#readme",
   "devDependencies": {
-    "react-native": "0.64.1",
-    "react-native-windows": "0.64.6"
+    "react-native": "^0.63.4",
+    "react-native-windows": "^0.63.14"
   }
 }

--- a/windows/RNSplashScreen/RNSplashScreen.vcxproj
+++ b/windows/RNSplashScreen/RNSplashScreen.vcxproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="ReactNativeWindowsProps">
-    <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
+    <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">


### PR DESCRIPTION
If a RNW application set up in a monorepo and its dependencies are symlinked into application's node_modules folder, `MSBuildThisFileDirectory` will point to the original directory of symlynked react-native-windows. 

However, when the application (and RNW in the node_modules folder) is built, the artifacts somehow not being copied to the original folder and staying only in the symlinked directory, which breaks the build (Visual Studio can't find Microsoft.ReactNative.winmd file), since MSBuildThisFileDirectory pointing to the original directory.

I think this has something to do with how symlinks work on Windows. Anyway, changing MSBuildThisFileDirectory to SolutionDir fixes this, and ReactNativeWindowsDir is poiting to the symlink location, and not the original directory.

My colleagues and I already made a few contributions adding this fix to other projects, such as react-native-device-infp PR [#1279](https://github.com/react-native-device-info/react-native-device-info/pull/1279), so hopefully we can have the same fix for this fork of react-native-splash-screen, which will eventually get into the original repository.